### PR TITLE
TP stream decoder fcl plus simplification of PDHDTriggerReader - no channel map needed

### DIFF
--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDTriggerReader_module.cc
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDTriggerReader_module.cc
@@ -22,7 +22,6 @@
 #include "detdataformats/trigger/TriggerActivityData.hpp"
 #include "detdataformats/trigger/TriggerCandidateData.hpp"
 #include "duneprototypes/Protodune/hd/RawDecoding/PDHDDataInterface.h"
-#include "duneprototypes/Protodune/hd/ChannelMap/PD2HDChannelMapService.h"
 
 #include <memory>
 #include <iostream>
@@ -90,7 +89,6 @@ void PDHDTriggerReader::produce(art::Event& e)
 
 
   // Fetches SourceIDs for the set of Fragments that have TriggerPrimitive data in them.
-  art::ServiceHandle<dune::PD2HDChannelMapService> channelMap;
   art::ServiceHandle<dune::HDF5RawFile2Service> rawFileService;
   auto rf = rawFileService->GetPtr();
  

--- a/duneprototypes/Protodune/hd/RawDecoding/runpdhdtpstreamdecoder.fcl
+++ b/duneprototypes/Protodune/hd/RawDecoding/runpdhdtpstreamdecoder.fcl
@@ -1,4 +1,4 @@
-#include "HDF5RawInput2.fcl"
+#include "HDF5TPStreamInput2.fcl"
 #include "PDHDTriggerReader.fcl"
 
 services:
@@ -6,7 +6,7 @@ services:
   TimeTracker:  {}
   TFileService: 
   {
-    fileName: "pdhdTriggerReaderTFile.root"
+    fileName: "TPStreamReaderTFile.root"
   } 
   HDF5RawFile2Service:  {}
 }
@@ -34,7 +34,7 @@ outputs:
   }
 }
 
-source: @local::hdf5rawinput2
+source: @local::hdf5tpstreaminput2
 
-process_name: pdhdtriggerreader
+process_name: tpstreamreader
 


### PR DESCRIPTION
I put the runpdhdtpstreamdecoder here because the TP, TA and TC decoder lives here in duneprototypes.  Since it is more general, we may think about moving it to duncore, but so far, only the coldboxes and protodunes have made TP stream data.  This PR is run-time coupled to https://github.com/DUNE/dunecore/pull/84 -- i.e., it will build fine (just a new fcl file) but will not run without the new TP Stream input source in dunecore.  I also removed mention of the channel map in the PDHD TP, TA and TC decoder.