### PR TITLE
added mean hit position in CRTVD::Trigger class

### DIFF
--- a/duneprototypes/Protodune/vd/CRT/CMakeLists.txt
+++ b/duneprototypes/Protodune/vd/CRT/CMakeLists.txt
@@ -15,6 +15,7 @@ art_make( MODULE_LIBRARIES
 			lardataobj_AnalysisBase
 			ROOT_BASIC_LIB_LIST
                         larcoreobj_SimpleTypesAndConstants
+                        larcorealg::GeoAlgo
 )
 
 install_headers()

--- a/duneprototypes/Protodune/vd/CRT/CRTVDSim_module.cc
+++ b/duneprototypes/Protodune/vd/CRT/CRTVDSim_module.cc
@@ -107,19 +107,13 @@ private:
 CRT::CRTVDSim::CRTVDSim(fhicl::ParameterSet const & p): EDProducer{p}, 
                                                               logInfo_("CRTVDSim"),
                                                               fSimLabel(p.get<art::InputTag>("SimLabel")), 
-                                                              /*fScintillationYield(p.get<double>("ScintillationYield")), 
-                                                              fQuantumEff(p.get<double>("QuantumEff")), 
-                                                              fDummyGain(p.get<double>("DummyGain")),*/
-                                                              //fGeVToADC(p.get<double>("GeVToADC")),
                                                               fIntegrationWindow(p.get<time>("IntegrationWindow")), 
                                                               fSamplingTime(p.get<time>("SamplingTime")), 
                                                               fDownwardWindow(p.get<time>("DownwardWindow")), 
                                                               fUpwardWindow(p.get<time>("UpwardWindow")), 
-                                                              //fReadoutWindowSize(p.get<size_t>("ReadoutWindowSize")), 
                                                               fDeadTime(p.get<size_t>("DeadTime")),
                                                               fEnergyThreshold(p.get<double>("EnergyThreshold")),
                                                               fSmearing(p.get<double>("Smearing"))
-                                                              //fDACThreshold(p.get<adc_t>("DACThreshold"))
 {
   produces<std::vector<CRTVD::Trigger>>();
   produces<art::Assns<simb::MCParticle,CRTVD::Trigger>>(); 
@@ -136,14 +130,14 @@ void CRT::CRTVDSim::produce(art::Event & e)
 
   // Get all AuxDetHits contained in the event
   auto const allSims = e.getMany<sim::AuxDetHitCollection>();
-std::cout << "aux det hit size : " << allSims.size() << std::endl;
+//std::cout << "aux det hit size : " << allSims.size() << std::endl;
 
   // -- Get all MCParticles to do assns later
   const auto & mcp_handle = e.getValidHandle<std::vector<simb::MCParticle>>("largeant"); // -- TODO: make this an input tag. Tag is correct though
   art::PtrMaker<simb::MCParticle> makeMCParticlePtr{e,mcp_handle.id()};
 //  art::ServiceHandle < cheat::ParticleInventoryService > partInventory; // seems useless
   auto const & mcparticles = *(mcp_handle); //dereference the handle
-std::cout << "MCParticle size = " << mcparticles.size() << std::endl;
+//std::cout << "MCParticle size = " << mcparticles.size() << std::endl;
 
   // -- Construct map of trackId to MCParticle handle index to do assns later
   std::unordered_map<int, int> map_trackID_to_handle_index;
@@ -218,6 +212,8 @@ std::cout << "energy deposited : = " << eDep.GetEnergyDeposited() << std::endl;
       }
       // smeared hit position
       geo::Point_t hp(x, y ,z);
+
+//std::cout << "Position : = " << hp.X() << " " << hp.Y() << " " << hp.Z() << std::endl; 
 
 
       crtHitsModuleMap[(eDep.GetID()-1)/8][tAvg/fSamplingTime].emplace_back(CRTVD::Hit( (eDep.GetID()-1)%8, volume, eDep.GetEnergyDeposited(), geo::Point_t(x, y, z)), eDep.GetTrackID() );
@@ -361,7 +357,6 @@ std::cout << "--- END bottom module only ---\n\n";
     for (auto pair : bottomHits) crtTrackedHitsModuleMap[0][t].emplace_back(pair);
   }
 
-std::cout << "\n---CHECK---\n" << std::endl;
 
   // store CRT activity
   for (int k=0; k<3; k++){ // trigerring type loop. 0 = top trigger only, 1 = bottom trigger only, 2 = coincidence trigger

--- a/duneprototypes/Protodune/vd/CRT/CRTVDSim_module.cc
+++ b/duneprototypes/Protodune/vd/CRT/CRTVDSim_module.cc
@@ -175,15 +175,16 @@ void CRT::CRTVDSim::produce(art::Event & e)
 /*
 std::cout << "\nHit in volume " << volume << std::endl;
 std::cout << "edep.GetID() = " << eDep.GetID() << std::endl;
-std::cout << "CRT volume index = " << (eDep.GetID()-1)/8 << std::endl;
+std::cout << "CRT volume index = " << (eDep.GetID())/8 << std::endl;
 std::cout << "CRT channel = " << (eDep.GetID()-1)%8 << std::endl;
 std::cout << "edep.GetTrackID() = " << eDep.GetTrackID() << std::endl;
 std::cout << "tAvg_fl = " << tAvg_fl << "\t" << "tAvg_int = " << tAvg << std::endl;
 std::cout << "Integration window = " << fIntegrationWindow << std::endl; 
 std::cout << "energy deposited : = " << eDep.GetEnergyDeposited() << std::endl; 
 */
+
       // Smear hit position from true position
-      const geo::AuxDetGeo& adg = geom->AuxDet( (eDep.GetID()-1)/8 );
+      const geo::AuxDetGeo& adg = geom->AuxDet( eDep.GetID()/8 );
 // adg.PrintAuxDetInfo(std::cout, "" , 3); std::cout << "\n";
       float x = midpoint.X();
       float y = midpoint.Y();
@@ -270,6 +271,7 @@ std::cout << "energy deposited : = " << eDep.GetEnergyDeposited() << std::endl;
             } // end loop over secondary bottom hits
          //} // end if
     } // end primary loop over bottom module hits
+
 /*
 // CHECK
 std::cout << "\n--- Check 1st bottom hit search ---" << std::endl;

--- a/duneprototypes/Protodune/vd/CRT/classes_def.xml
+++ b/duneprototypes/Protodune/vd/CRT/classes_def.xml
@@ -13,7 +13,9 @@
    <version ClassVersion="12" checksum="370505871"/>
    <version ClassVersion="11" checksum="2091418630"/>
   </class>
-  <class name="CRTVD::Trigger" ClassVersion="11">
+  <class name="CRTVD::Trigger" ClassVersion="13">
+   <version ClassVersion="13" checksum="718746011"/>
+   <version ClassVersion="12" checksum="2952548699"/>
    <version ClassVersion="11" checksum="2571201266"/>
   </class>
 


### PR DESCRIPTION
Small update from what was presented here : https://indico.fnal.gov/event/61808/
CRTVD::Trigger now store the mean spatial position of hit positions in CRT modules, possibly allowing for angle calculation of tracks triggering coincidences.