### PR TITLE
WIBEth3 decoder and TPC Monitor fcls for DUNE-DAQ 4.4.0

### DIFF
--- a/duneprototypes/Iceberg/WIBEth/run_iceberg_wibeth3_decoder.fcl
+++ b/duneprototypes/Iceberg/WIBEth/run_iceberg_wibeth3_decoder.fcl
@@ -1,0 +1,4 @@
+#include "run_pdhd_wibeth3_tpc_decoder.fcl"
+physics.producers.tpcrawdecoder.DecoderToolParams.DebugLevel: 0
+services.PD2HDChannelMapService.FileName: "iceberg_wibeth_chanmap_v1.txt"
+physics.producers.tpcrawdecoder.APAList: [ 8 ]

--- a/duneprototypes/Iceberg/WIBEth/run_iceberg_wibeth3_rawtpcmonitor.fcl
+++ b/duneprototypes/Iceberg/WIBEth/run_iceberg_wibeth3_rawtpcmonitor.fcl
@@ -1,0 +1,21 @@
+# Decode ICEBERG data and run the TPC monitor module
+# Takes advantage of the PDHD data interface tool and module
+# Configured to use the new WIBEth frames
+# The readout window size was set for run 000001, taken December 13,2023
+
+#include "PDHDDataInterfaceWIBEth3.fcl"
+#include "HDF5RawInput3.fcl"
+#include "PDHDTPCReader.fcl"
+#include "Iceberg_decode_rawtpcmonitor.fcl"
+
+source: @local::hdf5rawinput3
+services.HDF5RawFile3Service:  {}
+
+physics.producers.tpcrawdecoder: @local::PDHDTPCReaderDefaults
+physics.producers.tpcrawdecoder.DecoderToolParams: @local::PDHDDataInterfaceWIBEth3Defaults
+physics.producers.tpcrawdecoder.DecoderToolParams.DebugLevel: 0
+physics.producers.tpcrawdecoder.APAList: [ 8 ]
+
+services.PD2HDChannelMapService.FileName: "iceberg_wibeth_chanmap_v1.txt"
+services.DetectorPropertiesService.NumberTimeSamples: 8256
+services.DetectorPropertiesService.ReadOutWindowSize: 8256


### PR DESCRIPTION
Two new fcl files for ICEBERG, to be run with DUNE-DAQ 4.4.0's data format.  Data taken from May 2024 onwards.  From the iceberg-daq Slack channel:

Shekhar: if any of the above scripts need modifications and/or need new fcl.
 even though the hdf5 file using these scripts says we have 30 events, data is there in only 1st 2 events. ????

Tom: That's almost certainly because you are using a DAQ version with a different format from what the offline code is expecting.  Running experiments like to keep data formats constant for this reason.
 
Shekhar: ICEBERG will keep the DAQ version to fddaq-v4.4.1-a9 (unless forced to change due to DUNE-DAQ request). (edited)

-------

These are the relevant fcl changes. As with the previous WIBEth configurations, ICEBERG is re-using the PD-HD raw decoder, but we include the ICEBERG channel map and number of readout samples.  Enclosed below are event displays of one event in run 11484, TPC 0 and TPC 1, as well as a FFT plot from the TPC monitor fcl.

![iceberg11484fft](https://github.com/DUNE/duneprototypes/assets/11527579/3b01f22f-8afb-4e3a-9c06-f083af314255)
![iceberg11484_1_tpc0](https://github.com/DUNE/duneprototypes/assets/11527579/ff913cc5-a999-44f5-8fa2-0d646f33c172)
![iceberg11484_1_tpc1](https://github.com/DUNE/duneprototypes/assets/11527579/c6cd7121-c478-4471-8397-7dc7bce5cd19)
