### PR TITLE
add noise filter for protodune ground shake event

### DIFF
--- a/duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt
+++ b/duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt
@@ -32,6 +32,25 @@ cet_build_plugin(PDHDFEMBFilter art::module LIBRARIES
 		 lardataobj::RawData
                  ROOT::Core ROOT::Hist ROOT::Tree
                  BASENAME_ONLY
+                 dunecore::HDF5Utils_HDF5RawFile3Service_service
+                 dunecore::dunedaqhdf5utils2
+)
+
+
+cet_build_plugin(PDHDNoiseFilter art::module LIBRARIES
+                 art::Framework_Core
+                 art::Framework_Principal
+                 art::Framework_Services_Registry
+                 art_root_io::tfile_support
+                 ROOT::Core
+                 art::Persistency_Provenance
+                 duneprototypes_Protodune_hd_ChannelMap_PD2HDChannelMapService_service
+                 messagefacility::MF_MessageLogger
+         lardataobj::RawData
+                 ROOT::Core ROOT::Hist ROOT::Tree
+                 BASENAME_ONLY
+                 dunecore::HDF5Utils_HDF5RawFile3Service_service
+                 dunecore::dunedaqhdf5utils2
 )
 
 cet_build_plugin(DAPHNEReaderPDHD art::module LIBRARIES

--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDNoiseFilter.fcl
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDNoiseFilter.fcl
@@ -1,0 +1,9 @@
+BEGIN_PROLOG
+  pdhdnoisefilter: {
+    LogLevel: 0
+    module_type: "PDHDNoiseFilter"
+    RawDigitLabel: "tpcrawdecoder:daq"
+  }
+
+
+END_PROLOG

--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDNoiseFilter_module.cc
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDNoiseFilter_module.cc
@@ -1,0 +1,94 @@
+#include <iostream>
+#include <utility>
+#include <set>
+
+#include "art/Framework/Core/EDAnalyzer.h" 
+#include "art/Framework/Core/EDFilter.h" 
+#include "art/Framework/Core/ModuleMacros.h" 
+#include "art/Framework/Principal/Event.h" 
+#include "art_root_io/TFileService.h"
+
+#include "lardataobj/RawData/RawDigit.h"
+#include "dunecore/DuneObj/RDStatus.h"
+#include "duneprototypes/Protodune/hd/ChannelMap/PD2HDChannelMapService.h"
+
+#include <bitset>
+#include "TH1F.h"
+#include "TH2F.h"
+
+
+namespace pdhd {
+
+using RawDigitVector = std::vector<raw::RawDigit>;
+
+class PDHDNoiseFilter : public art::EDFilter {
+ public:
+  explicit PDHDNoiseFilter(fhicl::ParameterSet const & pset);
+  virtual ~PDHDNoiseFilter() {};
+  virtual bool filter(art::Event& e);
+
+ private:
+  std::string fRawDigitLabel;
+
+
+};
+
+PDHDNoiseFilter::PDHDNoiseFilter::PDHDNoiseFilter(fhicl::ParameterSet const & pset):
+  EDFilter(pset),
+  fRawDigitLabel(pset.get<std::string>("RawDigitLabel")){}
+
+
+bool PDHDNoiseFilter::filter(art::Event & evt) {
+
+
+  // auto const &rawdigits = *evt.getValidHandle<vector<raw::RawDigit>>(rawdigits_tag);
+  auto &rawdigits = *evt.getValidHandle<RawDigitVector>(fRawDigitLabel);
+  if (rawdigits.empty())
+        {
+            std::cout << "WARNING: no RawDigit found." << std::endl;
+            return false;
+        }  
+
+  const int nticks = rawdigits[0].Samples();
+  const int nchans = rawdigits.size();
+  // int Event_ = evt.id().event();
+  // std::cout<<"evt = "<<m_Event<<std::endl;
+  // std::cout<<"nticks = "<<nticks<<std::endl;
+  // std::cout<<"nchans = "<<nchans<<std::endl;
+  TH2F *h_orig = new TH2F("h_orig", "RawDigits", nchans, -0.5, nchans - 0.5, nticks, 0, nticks);
+
+  for (auto rd : rawdigits){
+            int channel = rd.Channel();
+            // int nSamples = rd.Samples();
+            for (int j = 0; j < nticks; j++)
+            {
+                h_orig->SetBinContent(channel + 1, j + 1, rd.ADC(j) - rd.GetPedestal());
+            }
+  } // end of rawdigits
+
+  // Project all channels to 1D.
+  TH1F *hhh = new TH1F("hhh","hhh",nticks,0,nticks);
+  for(int j=0;j<nticks;j++){
+      TH1F *h1 = (TH1F *)h_orig->ProjectionX("proj_x", j+1, j+1);
+      h1->SetDirectory(0);
+      int val = h1->Integral();
+      hhh->SetBinContent(j+1,val);
+      delete h1;
+  }
+  double diff = hhh->GetMaximum()-hhh->GetMinimum();
+  //cout<<"diff = "<<hhh->GetMaximum()-hhh->GetMinimum()<<endl;
+  delete hhh;
+  delete h_orig;
+  if(diff>1e7){
+        std::cout<<"found! Groud shake noise at Evt "<<evt.id().event()<<std::endl;
+        return false;
+  }
+  // std::cout<<"Groud shake noise filter applied"<<std::endl;
+  return true;
+}
+
+
+
+DEFINE_ART_MODULE(PDHDNoiseFilter)
+
+}


### PR DESCRIPTION
Filter out the so-called "ground shake" noise. 

If needed, this filter can be added to the PDHD stage1: standard_reco_protodunehd_keepup.fcl

And use it in the reco stage1:

physics.produce: [
  tpcrawdecoder,
  triggerrawdecoder,
  timingrawdecoder,
  pdhddaphne,
  fembfilter,
  pdhdhnoisefilter,
  wclsdatahdfilter  #new to output raw digits from Wirecell
]

![image](https://github.com/user-attachments/assets/8f2d7b9c-6549-4c21-aa3b-044a99d46722)
![image](https://github.com/user-attachments/assets/e29e9323-67dd-4d94-881b-3d4cefa7a5e0)
