### PR TITLE
Central Trigger Board (CTB) decoder and Cherenkov filter

### DIFF
--- a/duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt
+++ b/duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt
@@ -203,6 +203,43 @@ cet_build_plugin(PDHDTriggerReader3 art::module LIBRARIES
                         BASENAME_ONLY
                 )
 
+cet_build_plugin(PDHDCTBRawDecoder art::module LIBRARIES
+		lardataobj::RawData
+		dunecore::HDF5Utils_HDF5RawFile3Service_service
+		dunecore::dunedaqhdf5utils2
+		HDF5::HDF5
+		art::Framework_Core
+		art::Framework_Principal
+		art::Framework_Services_Registry
+		art_root_io::tfile_support
+		artdaq_core::artdaq-core_Data
+		artdaq_core::artdaq-core_Utilities
+		ROOT::Core
+		art_root_io::TFileService_service
+		art::Persistency_Provenance
+		art::Utilities
+		messagefacility::MF_MessageLogger
+		dunecore::dunedaqhdf5utils3
+		ROOT::Core ROOT::Hist ROOT::Tree
+		BASENAME_ONLY
+)
+
+cet_build_plugin(PDHDCherenkovTriggerBitsFilter art::module LIBRARIES
+		art::Framework_Core
+		art::Framework_Principal
+		art::Framework_Services_Registry
+		art_root_io::tfile_support
+		ROOT::Core
+		art::Persistency_Provenance
+		duneprototypes_Protodune_hd_ChannelMap_PD2HDChannelMapService_service
+		messagefacility::MF_MessageLogger
+		lardataobj::RawData
+		ROOT::Core ROOT::Hist ROOT::Tree
+		BASENAME_ONLY
+		dunecore::HDF5Utils_HDF5RawFile3Service_service
+		dunecore::dunedaqhdf5utils2
+)
+
 cet_make_library(LIBRARY_NAME DAPHNEUtils INTERFACE
                  SOURCE DAPHNEUtils.cxx
                  LIBRARIES

--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDCTBRawDecoder.fcl
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDCTBRawDecoder.fcl
@@ -1,0 +1,16 @@
+# defaults for the PDHDCTBRawDecoder module
+
+BEGIN_PROLOG
+
+PDHDCTBRawDecoderDefaults:
+{
+  module_type: "PDHDCTBRawDecoder"
+  InputLabel:  "daq"
+  ProcessLLTs: true
+  ProcessHLTs: true
+  OutputInstanceLLT: "ctbLLT"
+  OutputInstanceHLT: "ctbHLT"
+  DebugLevel: 0
+}
+
+END_PROLOG

--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDCTBRawDecoder_module.cc
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDCTBRawDecoder_module.cc
@@ -1,0 +1,168 @@
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Utilities/make_tool.h" 
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "art/Persistency/Common/PtrMaker.h"
+
+#include "dunecore/DuneObj/DUNEHDF5FileInfo2.h"
+#include "dunecore/HDF5Utils/HDF5RawFile3Service.h"
+#include "detdataformats/hsi/HSIFrame.hpp"
+
+#include <memory>
+#include <iostream>
+
+class PDHDCTBRawDecoder;
+
+class PDHDCTBRawDecoder : public art::EDProducer {
+public:
+    explicit PDHDCTBRawDecoder(fhicl::ParameterSet const& p);
+    // The compiler-generated destructor is fine for non-base
+    // classes without bare pointers or other resource use.
+
+    // Plugins should not be copied or assigned.
+    PDHDCTBRawDecoder(PDHDCTBRawDecoder const&) = delete;
+    PDHDCTBRawDecoder(PDHDCTBRawDecoder&&) = delete;
+    PDHDCTBRawDecoder& operator=(PDHDCTBRawDecoder const&) = delete;
+    PDHDCTBRawDecoder& operator=(PDHDCTBRawDecoder&&) = delete;
+
+    // Required functions.
+    void produce(art::Event& e) override;
+
+private:
+
+    std::string fInputLabel;
+
+    bool fProcessLLTs;
+    bool fProcessHLTs;
+    std::string fOutputInstance_LLT;
+    std::string fOutputInstance_HLT;
+    int fDebugLevel;
+};
+
+
+PDHDCTBRawDecoder::PDHDCTBRawDecoder(fhicl::ParameterSet const& p)
+    : EDProducer{p}
+    , fInputLabel(p.get<std::string>("InputLabel","daq"))
+    , fProcessLLTs(p.get<bool>("ProcessLLTs",true))
+    , fProcessHLTs(p.get<bool>("ProcessHLTs",true))
+    , fOutputInstance_LLT(p.get<std::string>("OutputInstance_LLT","daqLLT"))
+    , fOutputInstance_HLT(p.get<std::string>("OutputInstance_HLT","daqHLT"))
+    , fDebugLevel(p.get<int>("DebugLevel",0))
+{
+    if(fProcessLLTs) produces<std::vector<dunedaq::detdataformats::HSIFrame>>(fOutputInstance_LLT);
+    if(fProcessHLTs) produces<std::vector<dunedaq::detdataformats::HSIFrame>>(fOutputInstance_HLT);
+
+    consumes<raw::DUNEHDF5FileInfo2>(fInputLabel);  // the tool actually does the consuming of this product
+}
+
+
+
+void PDHDCTBRawDecoder::produce(art::Event& e) {
+
+    std::vector<dunedaq::detdataformats::HSIFrame> hsi_llt_col, hsi_hlt_col;
+
+    auto infoHandle = e.getHandle<raw::DUNEHDF5FileInfo2>(fInputLabel);
+
+    const std::string & file_name = infoHandle->GetFileName();
+    uint32_t runno = infoHandle->GetRun();
+    size_t   evtno = infoHandle->GetEvent();
+    size_t   seqno = infoHandle->GetSequence();
+
+    dunedaq::hdf5libs::HDF5RawDataFile::record_id_t rid = std::make_pair(evtno, seqno);
+  
+    if (fDebugLevel > 0){
+        std::cout << "PDHDDataInterface HDF5 FileName: " << file_name << std::endl;
+        std::cout << "PDHDDataInterface Run:Event:Seq: " << runno << ":" << evtno << ":" << seqno << std::endl;
+    }
+
+    // Grab the source ids for fragments with HSI frames
+    art::ServiceHandle<dune::HDF5RawFile3Service> rawFileService;
+    auto rf = rawFileService->GetPtr();
+    auto trh_timestamp = rf->get_trh_ptr(rid)->get_trigger_timestamp();
+
+    if (fDebugLevel > 0){
+        std::cout << "PDHDDataInterface Trigger Timestamp: " << trh_timestamp << std::endl;
+    }
+
+
+    auto hsi_sourceids = rf->get_source_ids_for_fragment_type(rid,dunedaq::daqdataformats::FragmentType::kHardwareSignal);
+
+    // Loop over SourceIDs, Calculates the number of TriggerPrimitive objects in the individual Fragment Payload
+    if (fDebugLevel > 0){
+        std::cout << "\t N_HSI_SourceIDs: " << hsi_sourceids.size() << std::endl;
+    }
+ 
+    for (auto const& source_id : hsi_sourceids){
+        // Perform a check to make sure we are only grabbing information from the HwSignalsInterface
+        if (source_id.subsystem != dunedaq::daqdataformats::SourceID::Subsystem::kHwSignalsInterface) continue;
+
+        //get the fragment and number of contained HSI frames
+        auto frag_ptr = rf->get_frag_ptr(rid, source_id);
+        size_t n_frames = frag_ptr->get_data_size() / sizeof(dunedaq::detdataformats::HSIFrame);
+        auto frag_data_ptr = (char*)frag_ptr->get_data();
+
+        //loop over the HSI frames
+        for(size_t iframe=0; iframe<n_frames; ++iframe){
+            auto hsi_frame = *(reinterpret_cast<dunedaq::detdataformats::HSIFrame*>(frag_data_ptr+iframe*sizeof(dunedaq::detdataformats::HSIFrame)));
+
+            //check if LLT or HLT, and push back onto output collections
+            auto link_no = hsi_frame.link;
+            if(fProcessLLTs && link_no==0)
+                hsi_llt_col.push_back(hsi_frame);
+            if(fProcessHLTs && link_no==1)
+                hsi_hlt_col.push_back(hsi_frame);
+
+            //debug print statement
+            if(fDebugLevel>1){
+                if(link_no==0) std::cout << "\t\tLLT: ";
+                else if(link_no==1) std::cout << "\t\tHLT: ";
+                else std::cout << "\t\t???: ";
+
+                std::cout << "TS=" << hsi_frame.get_timestamp();
+
+                size_t position=0;
+                std::cout << " Trigger=";
+                auto val = hsi_frame.trigger;
+                while(val>0) {
+                    if (val & 1) std::cout << position << ",";
+                    val = val >> 1;
+                    position++;
+                }
+
+                position=0;
+                std::cout << " Inputs=";
+                val = hsi_frame.input_low;
+                while(val>0) {
+                    if (val & 1) std::cout << position << ",";
+                    val = val >> 1;
+                    position++;
+                }
+                position=0;
+                val = hsi_frame.input_high;
+                while(val>0) {
+                    if (val & 1) std::cout << position+32 << ",";
+                    val = val >> 1;
+                    position++;
+                }
+                std::cout << std::endl;
+
+            }
+        }
+    }
+
+    if(fProcessLLTs)
+        e.put(std::make_unique<std::vector<dunedaq::detdataformats::HSIFrame>>(std::move(hsi_llt_col)),fOutputInstance_LLT);
+    if(fProcessHLTs)
+        e.put(std::make_unique<std::vector<dunedaq::detdataformats::HSIFrame>>(std::move(hsi_hlt_col)),fOutputInstance_HLT);
+
+}
+
+DEFINE_ART_MODULE(PDHDCTBRawDecoder)

--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter.fcl
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter.fcl
@@ -8,6 +8,7 @@ PDHDCherebkovTriggerBitsFilterDefault:
        TriggerTimestampLabel: "timingrawdecoder:daq"
        LLTLabel: "ctbrawdecoder:daqLLT"
        CherenkovTriggers: ["HxLx","HLx"]
+       PassIfNoLLTs: false
        DebugLevel: 0
 }
 

--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter.fcl
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter.fcl
@@ -1,0 +1,14 @@
+# defaults for the PDHDCTBRawDecoder module
+
+BEGIN_PROLOG
+
+PDHDCherebkovTriggerBitsFilterDefault:
+{
+       module_type: "PDHDCherenkovTriggerBitsFilter"
+       TriggerTimestampLabel: "timingrawdecoder:daq"
+       LLTLabel: "ctbrawdecoder:daqLLT"
+       CherenkovTriggers: ["HxLx","HLx"]
+       DebugLevel: 0
+}
+
+END_PROLOG

--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter_module.cc
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter_module.cc
@@ -32,6 +32,8 @@ class PDHDCherenkovTriggerBitsFilter : public art::EDFilter {
     std::string fTriggerTimestampLabel;
     std::string fLLTLabel;
 
+    bool fPassIfNoLLTs;
+
     std::set<std::string> fCherenkovTriggers;
     int fTimeToleranceDTSTicks;
 
@@ -43,6 +45,7 @@ PDHDCherenkovTriggerBitsFilter::PDHDCherenkovTriggerBitsFilter::PDHDCherenkovTri
   : EDFilter(pset)
   , fTriggerTimestampLabel(pset.get<std::string>("TriggerTimestampLabel"))
   , fLLTLabel(pset.get<std::string>("LLTLabel"))
+  , fPassIfNoLLTs(pset.get<bool>("PassIfNoLLTs",false))
   , fTimeToleranceDTSTicks(pset.get<int>("TimeToleranceDTSTicks",5))
   , fDebugLevel(pset.get<int>("DebugLevel",0))
 {
@@ -74,7 +77,7 @@ bool PDHDCherenkovTriggerBitsFilter::filter(art::Event & evt) {
     auto &llt_hsi_frames = *evt.getValidHandle<std::vector<dunedaq::detdataformats::HSIFrame>>(fLLTLabel);
     if(llt_hsi_frames.size()==0) {
         std::cout << "WARNING: NO LLT WORDS FOUND!" << std::endl;
-        return false;
+        return fPassIfNoLLTs;
     }
 
     if(fDebugLevel>0){

--- a/duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter_module.cc
+++ b/duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter_module.cc
@@ -1,0 +1,136 @@
+#include <iostream>
+#include <utility>
+#include <set>
+
+#include "art/Framework/Core/EDAnalyzer.h" 
+#include "art/Framework/Core/EDFilter.h" 
+#include "art/Framework/Core/ModuleMacros.h" 
+#include "art/Framework/Principal/Event.h" 
+#include "art_root_io/TFileService.h"
+
+#include "detdataformats/hsi/HSIFrame.hpp"
+#include "lardataobj/RawData/RDTimeStamp.h"
+
+#include <set>
+
+
+namespace pdhd {
+
+class PDHDCherenkovTriggerBitsFilter : public art::EDFilter {
+
+    static constexpr unsigned int const LLT_LPCHKV_MASK = 1 << 3; //LLT_3
+    static constexpr unsigned int const LLT_HPCHKV_MASK = 1 << 2; //LLT_2
+
+    const std::set<std::string> ALLOWED_CHERENKOV_TRIGGERS = { "HL","HLx","HxL","HxLx" };
+
+ public:
+    explicit PDHDCherenkovTriggerBitsFilter(fhicl::ParameterSet const & pset);
+    virtual ~PDHDCherenkovTriggerBitsFilter() {};
+    virtual bool filter(art::Event& e);
+
+ private:
+    std::string fTriggerTimestampLabel;
+    std::string fLLTLabel;
+
+    std::set<std::string> fCherenkovTriggers;
+    int fTimeToleranceDTSTicks;
+
+    int fDebugLevel;
+
+};
+
+PDHDCherenkovTriggerBitsFilter::PDHDCherenkovTriggerBitsFilter::PDHDCherenkovTriggerBitsFilter(fhicl::ParameterSet const & pset)
+  : EDFilter(pset)
+  , fTriggerTimestampLabel(pset.get<std::string>("TriggerTimestampLabel"))
+  , fLLTLabel(pset.get<std::string>("LLTLabel"))
+  , fTimeToleranceDTSTicks(pset.get<int>("TimeToleranceDTSTicks",5))
+  , fDebugLevel(pset.get<int>("DebugLevel",0))
+{
+    std::vector<std::string> input_cts = pset.get< std::vector<std::string> >("CherenkovTriggers");
+    for(auto const& ct : input_cts) {
+        if (ALLOWED_CHERENKOV_TRIGGERS.count(ct) == 0)
+            throw cet::exception("PDHDCherenkovTriggerBitsFilter")
+                    << "UNKNOWN CHERENKOV TRIGGER TYPE " << ct << ". Must be 'HL', 'HLx', 'HxL', or 'HxLx'.";
+        fCherenkovTriggers.insert(ct);
+    }
+}
+
+
+bool PDHDCherenkovTriggerBitsFilter::filter(art::Event & evt) {
+
+    auto &trigger_timestamps = *evt.getValidHandle<std::vector<raw::RDTimeStamp>>(fTriggerTimestampLabel);
+    if(trigger_timestamps.size()!=1) {
+        throw cet::exception("PDHDCherenkovTriggerBitsFilter") <<
+            "ERROR: WRONG NUMBER OF TRIGGER TIMESTAMPS (" << trigger_timestamps.size() << ") FOUND";
+    }
+
+    long long int trigger_timestamp = trigger_timestamps.at(0).GetTimeStamp();
+
+    if(fDebugLevel>0){
+        std::cout << "Trigger timestamp= " << trigger_timestamp << std::endl;
+    }
+
+
+    auto &llt_hsi_frames = *evt.getValidHandle<std::vector<dunedaq::detdataformats::HSIFrame>>(fLLTLabel);
+    if(llt_hsi_frames.size()==0) {
+        std::cout << "WARNING: NO LLT WORDS FOUND!" << std::endl;
+        return false;
+    }
+
+    if(fDebugLevel>0){
+        std::cout << "Found " << llt_hsi_frames.size() << " LLT HSI frames." << std::endl;
+    }
+
+    bool found_lpchkv_hit = false;
+    bool found_hpchkv_hit = false;
+    for(auto const& llt_frame : llt_hsi_frames){
+
+        if(fDebugLevel>1){
+            std::cout << "\t\tLLT -- Timestamp=" << llt_frame.get_timestamp()
+                      << "  TriggerBits=" << llt_frame.trigger << std::endl;
+        }
+
+        long long int llt_timestamp = llt_frame.get_timestamp();
+        if(std::abs(llt_timestamp-trigger_timestamp)>fTimeToleranceDTSTicks) continue;
+
+        if(fDebugLevel>0){
+            std::cout << "\t\tMatching LLT (tdiff=" << std::abs(llt_timestamp-trigger_timestamp) << ")."
+                      << " LP hit? " << (llt_frame.trigger & LLT_LPCHKV_MASK)
+                      << " HP hit? " << (llt_frame.trigger & LLT_HPCHKV_MASK)
+                      << std::endl;
+        }
+
+        if(llt_frame.trigger & LLT_LPCHKV_MASK) found_lpchkv_hit = true;
+        if(llt_frame.trigger & LLT_HPCHKV_MASK) found_hpchkv_hit = true;
+
+    }
+
+    std::string ct="";
+    if(found_hpchkv_hit&&found_lpchkv_hit) ct="HL";
+    else if(found_hpchkv_hit&&!found_lpchkv_hit) ct="HLx";
+    else if(!found_hpchkv_hit&&found_lpchkv_hit) ct="HxL";
+    else ct="HxLx";
+
+    if(fDebugLevel>0){
+        std::cout << "Trigger type " << ct << std::endl;
+    }
+
+    if(fCherenkovTriggers.count(ct)==1) {
+        if(fDebugLevel>0){
+            std::cout << "Filter pass" << std::endl;
+        }
+        return true;
+    }
+    else {
+        if(fDebugLevel>0){
+            std::cout << "Filter fail" << std::endl;
+        }
+        return false;
+    }
+}
+
+
+
+DEFINE_ART_MODULE(PDHDCherenkovTriggerBitsFilter)
+
+}

--- a/duneprototypes/Protodune/hd/RawDecoding/run_pdhd_trigger_timing.fcl
+++ b/duneprototypes/Protodune/hd/RawDecoding/run_pdhd_trigger_timing.fcl
@@ -1,6 +1,7 @@
 #include "HDF5RawInput3.fcl"
 #include "PDHDTriggerReader3.fcl"
 #include "PDHDTimingRawDecoder.fcl"
+#include "PDHDCTBRawDecoder.fcl"
 
 services:
 {
@@ -17,10 +18,11 @@ physics:
   producers:
   {
     triggerrawdecoder: @local::PDHDTriggerReader3Defaults
-    timingrawdecoder: @local::PDHDTimingRawDecoder
+    timingrawdecoder:  @local::PDHDTimingRawDecoder
+    ctbrawdecoder:     @local::PDHDCTBRawDecoderDefaults
   }
 
-  produce: [ triggerrawdecoder, timingrawdecoder ] 
+  produce: [ triggerrawdecoder, timingrawdecoder, ctbrawdecoder ]
   output: [ out1 ]
   trigger_paths : [ produce ]
   end_paths: [ output ]
@@ -40,3 +42,4 @@ source: @local::hdf5rawinput3
 
 process_name: pdhdtriggerreader
 
+physics.producers.ctbrawdecoder.DebugLevel: 5


### PR DESCRIPTION
Requires https://github.com/DUNE/dunecore/pull/116

This PR adds a new decoding module (duneprototypes/Protodune/hd/RawDecoding/PDHDCTBRawDecoder_module.cc) that reads in the collections of HSIFrame objects produced by the protodune CTB, and writes them to two collections: low-level trigger words (LLTs) and high-level trigger words (HLTs). The HSIFrame objects are written directly to the event -- if desired, we could construct an LLT / HLT object to decode into instead. There are options to turn off writing of the LLT or HLT collections if desired. The module is added to the `duneprototypes/Protodune/hd/RawDecoding/run_pdhd_trigger_timing.fcl` runtime fcl.

This PR also adds a new filter module (duneprototypes/Protodune/hd/RawDecoding/PDHDCherenkovTriggerBitsFilter_module.cc) that will read in the collection of LLTs (from the decoder above), identify the LLTs within a time tolerance of the trigger time (default 5 DTS ticks), determine if the high pressure and/or low pressure cherenkov detectors fired in coincidence with the beam trigger, and then filter based on the result.

What trigger bits to filter on is specified by a fcl parameter `CherenkovTriggers`, which is a list containing any of "HL" (both high and low fired), "HxL" (low fired, but not high), "HLx" (high fired, but not low), or "HxLx" (neither high nor low fired). The filter will return true of the LLT bits found match one of the specified triggers. It will return false if the LLT bits do not match the desired triggers. There is a configurable option `PassIfNoLLTs` to control behavior if there are no LLTs in the event (defaults to false).

The filter may not be entirely useful on its own, but in conjunction with checking higher-level trigger bits, it may be used for properly filtering based on Cherenkov information independent of the assignment of the HLTs (which, prior to fixes in mid August, were buggy).