### PR TITLE
fix drift sign in the PDSP-specific service provider initialization

### DIFF
--- a/duneprototypes/Protodune/singlephase/DetectorServices/Providers/DetectorPropertiesProtoDUNEsp.cxx
+++ b/duneprototypes/Protodune/singlephase/DetectorServices/Providers/DetectorPropertiesProtoDUNEsp.cxx
@@ -545,7 +545,7 @@ namespace spdp{
       for(auto const& tpcg : fGeo->Iterate<geo::TPCGeo>(cryostat.ID())) {
         auto const& tpcid = tpcg.ID();
         auto const tpc = tpcid.TPC;
-        const double dir(to_int(tpcg.DriftSign()));
+        const double dir(-to_int(tpcg.DriftSign()));
         drift_direction[cstat][tpc] = dir;
         int nplane = fWireReadoutGeom->Nplanes(tpcid);
         x_ticks_offsets[cstat][tpc].resize(nplane, 0.);


### PR DESCRIPTION
Extend the fix of 

https://github.com/LArSoft/lardataalg/commit/009551b1203bb03546db94060354e54fcacec6db

that didn't make it in to the ProtoDUNE-SP specific version of the DetectorPropertiesData initialization.  The commit above fixes the DetectorPropertiesStandard version but not the PDSP-specific version.  Fix is here.