### PR TITLE
change default channel map for PDHD to the visible wires from the electronics map

### DIFF
--- a/duneprototypes/Protodune/hd/RawDecoding/run_pdhd_wibeth3_tpc_decoder.fcl
+++ b/duneprototypes/Protodune/hd/RawDecoding/run_pdhd_wibeth3_tpc_decoder.fcl
@@ -20,6 +20,6 @@ services:
   HDF5RawFile3Service:  {}
   PD2HDChannelMapService:
    {
-     FileName: "PD2HDChannelMap_WIBEth_electronics_v1.txt"
+     FileName: "PD2HDChannelMap_WIBEth_visiblewires_v1.txt"
    }
 }

--- a/duneprototypes/Protodune/hd/RawDecoding/run_pdhd_wibeth_tpc_decoder.fcl
+++ b/duneprototypes/Protodune/hd/RawDecoding/run_pdhd_wibeth_tpc_decoder.fcl
@@ -3,4 +3,4 @@
 
 physics.producers.tpcrawdecoder.DecoderToolParams: @local::PDHDDataInterfaceWIBEthDefaults
 
-services.PD2HDChannelMapService.FileName: "PD2HDChannelMap_WIBEth_electronics_v1.txt"
+services.PD2HDChannelMapService.FileName: "PD2HDChannelMap_WIBEth_visiblewires_v1.txt"


### PR DESCRIPTION
See https://indico.fnal.gov/event/55149/contributions/245059/attachments/156640/204540/trjchanmapjune2022.pdf
for a description of why this is needed.  The channel map befor this PR was the "electronics" version, where wires end at the electronics boards.  But the geometry assumes wires are active to their endpoints, and the endpoints are lined up for the upright and inverted APAs.  So a rotation of 3 wires is needed for the WIBEth map as well as the other pre-WIBEth maps.  This PR just makes that map the default for the decoder fcls.  Enclosed are event displays befor eand after for a particular event in run 28550, for TPCs 1 and 2.
![tpc2_withvisiblewiremap](https://github.com/user-attachments/assets/2ac33fb1-ee5a-4d42-909e-1fdd0f8b0066)
![tpc1_withvisiblewiremap](https://github.com/user-attachments/assets/dbe07179-e208-4c03-b235-ad0b35c97c84)
![evd twq-proj 28550 5tpc1](https://github.com/user-attachments/assets/eced7fc9-d7cf-44ec-912d-8ea42e54633f)
![evd twq-proj 28550 5tpc2](https://github.com/user-attachments/assets/52647824-312f-449d-85e4-0c37ed6b5bb6)
