### PR TITLE
Trigger Reader Module using April 2025 TP, TA and TC formats

### DIFF
--- a/duneprototypes/Protodune/vd/RawDecoding/CMakeLists.txt
+++ b/duneprototypes/Protodune/vd/RawDecoding/CMakeLists.txt
@@ -49,7 +49,6 @@ cet_build_plugin(PDVDDataInterfaceWIBEth   art::tool LIBRARIES
 cet_build_plugin(PDVDTriggerReader3 art::module LIBRARIES
                         lardataobj::RawData
                         dunecore::HDF5Utils_HDF5RawFile3Service_service
-                        dunecore::dunedaqhdf5utils2
                         HDF5::HDF5
                         art::Framework_Core
                         art::Framework_Principal
@@ -67,6 +66,26 @@ cet_build_plugin(PDVDTriggerReader3 art::module LIBRARIES
                         BASENAME_ONLY
                 )
 
+cet_build_plugin(PDVDTriggerReader4 art::module LIBRARIES
+                        lardataobj::RawData
+                        dunecore::HDF5Utils_HDF5RawFile3Service_service
+                        HDF5::HDF5
+                        art::Framework_Core
+                        art::Framework_Principal
+                        art::Framework_Services_Registry
+                        art_root_io::tfile_support
+                        artdaq_core::artdaq-core_Data
+                        artdaq_core::artdaq-core_Utilities
+                        ROOT::Core
+                        art_root_io::TFileService_service
+                        art::Persistency_Provenance
+			art::Utilities
+                        messagefacility::MF_MessageLogger
+                        dunecore::dunedaqhdf5utils3
+                        ROOT::Core ROOT::Hist ROOT::Tree
+                        BASENAME_ONLY
+                )
+		
 
 install_headers()
 install_fhicl()

--- a/duneprototypes/Protodune/vd/RawDecoding/PDVDTriggerReader4.fcl
+++ b/duneprototypes/Protodune/vd/RawDecoding/PDVDTriggerReader4.fcl
@@ -1,0 +1,12 @@
+# defaults for the PDVDTriggerReader3 module
+
+BEGIN_PROLOG
+
+PDVDTriggerReader4Defaults:
+{
+  module_type: "PDVDTriggerReader4"
+  InputLabel:  "daq"
+  OutputInstance: "daq"
+}
+
+END_PROLOG

--- a/duneprototypes/Protodune/vd/RawDecoding/PDVDTriggerReader4.fcl
+++ b/duneprototypes/Protodune/vd/RawDecoding/PDVDTriggerReader4.fcl
@@ -1,4 +1,4 @@
-# defaults for the PDVDTriggerReader3 module
+# defaults for the PDVDTriggerReader4 module
 
 BEGIN_PROLOG
 

--- a/duneprototypes/Protodune/vd/RawDecoding/PDVDTriggerReader4_module.cc
+++ b/duneprototypes/Protodune/vd/RawDecoding/PDVDTriggerReader4_module.cc
@@ -1,0 +1,268 @@
+// very similar module to PDVDTriggerReader3_module.cc, though this one uses the packed TP, TA and TC data formats
+// released in April 2025.
+// The TP, TA and TC structs have the same struct names but the namespaces have been updated from
+// dunedaq::trgdataformats to dunedaq::trgdataformats2 so we can keep the old ones in their namespace
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Utilities/make_tool.h" 
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "art/Persistency/Common/PtrMaker.h"
+
+#include "lardataobj/RawData/RawDigit.h"
+#include "lardataobj/RawData/RDTimeStamp.h"
+#include "dunecore/DuneObj/RDStatus.h"
+#include "dunecore/DuneObj/DUNEHDF5FileInfo2.h"
+#include "dunecore/HDF5Utils/HDF5RawFile3Service.h"
+#include "detdataformats/trigger/TriggerObjectOverlay2.hpp"
+#include "detdataformats/trigger/TriggerPrimitive2.hpp"
+#include "detdataformats/trigger/TriggerActivityData2.hpp"
+#include "detdataformats/trigger/TriggerCandidateData2.hpp"
+
+#include <memory>
+#include <iostream>
+
+class PDVDTriggerReader4;
+
+class PDVDTriggerReader4 : public art::EDProducer {
+public:
+  explicit PDVDTriggerReader4(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  PDVDTriggerReader4(PDVDTriggerReader4 const&) = delete;
+  PDVDTriggerReader4(PDVDTriggerReader4&&) = delete;
+  PDVDTriggerReader4& operator=(PDVDTriggerReader4 const&) = delete;
+  PDVDTriggerReader4& operator=(PDVDTriggerReader4&&) = delete;
+
+  // Required functions.
+  void produce(art::Event& e) override;
+
+private:
+
+  std::string fInputLabel;
+  std::string fOutputInstance;
+  int fDebugLevel;
+};
+
+
+PDVDTriggerReader4::PDVDTriggerReader4(fhicl::ParameterSet const& p)
+  : EDProducer{p},
+  fInputLabel(p.get<std::string>("InputLabel","daq")),
+  fOutputInstance(p.get<std::string>("OutputInstance","daq")),
+  fDebugLevel(p.get<int>("DebugLevel",0))
+{
+  produces<std::vector<dunedaq::trgdataformats2::TriggerPrimitive>>(fOutputInstance);
+
+  //TriggerActivity objects are TriggerActivityData with a list of the contained TPs.
+  //Implement that as Assn between TriggerActivityData and TriggerPrimitive here
+  produces<std::vector<dunedaq::trgdataformats2::TriggerActivityData>>(fOutputInstance);
+  produces<std::vector<dunedaq::trgdataformats2::TriggerPrimitive>>(fOutputInstance+"inTAs");
+  produces<art::Assns<dunedaq::trgdataformats2::TriggerActivityData,dunedaq::trgdataformats2::TriggerPrimitive>>(fOutputInstance);
+
+  //TriggerCandidate objects are TriggerCandidateData with a list of the contained TAs.
+  //Implement that as Assn between TriggerCandidateData and TriggerActivityData here
+  produces<std::vector<dunedaq::trgdataformats2::TriggerCandidateData>>(fOutputInstance);
+  produces<std::vector<dunedaq::trgdataformats2::TriggerActivityData>>(fOutputInstance+"inTCs");
+  produces<art::Assns<dunedaq::trgdataformats2::TriggerCandidateData,dunedaq::trgdataformats2::TriggerActivityData>>(fOutputInstance);
+
+  consumes<raw::DUNEHDF5FileInfo2>(fInputLabel);  // the tool actually does the consuming of this product
+}
+
+
+
+void PDVDTriggerReader4::produce(art::Event& e)
+{
+
+  std::vector<dunedaq::trgdataformats2::TriggerPrimitive> tp_col, tps_in_tas_col;
+  std::vector<dunedaq::trgdataformats2::TriggerActivityData> ta_col, tas_in_tcs_col;
+  std::vector<dunedaq::trgdataformats2::TriggerCandidateData> tc_col;
+
+  art::Assns<dunedaq::trgdataformats2::TriggerActivityData,dunedaq::trgdataformats2::TriggerPrimitive> tp_in_tas_assn;
+  art::Assns<dunedaq::trgdataformats2::TriggerCandidateData,dunedaq::trgdataformats2::TriggerActivityData> ta_in_tcs_assn;
+
+  art::PtrMaker<dunedaq::trgdataformats2::TriggerActivityData> taPtrMaker(e,fOutputInstance);
+  art::PtrMaker<dunedaq::trgdataformats2::TriggerCandidateData> tcPtrMaker(e,fOutputInstance);
+  art::PtrMaker<dunedaq::trgdataformats2::TriggerPrimitive> tpInTAPtrMaker(e,fOutputInstance+"inTAs");
+  art::PtrMaker<dunedaq::trgdataformats2::TriggerActivityData> taInTCPtrMaker(e,fOutputInstance+"inTCs");
+
+  auto infoHandle = e.getHandle<raw::DUNEHDF5FileInfo2>(fInputLabel);
+  const std::string & file_name = infoHandle->GetFileName();
+  uint32_t runno = infoHandle->GetRun();
+  size_t   evtno = infoHandle->GetEvent();
+  size_t   seqno = infoHandle->GetSequence();
+
+  dunedaq::hdf5libs::HDF5RawDataFile::record_id_t rid = std::make_pair(evtno, seqno);
+  
+  if (fDebugLevel > 0)
+    {
+      std::cout << "PDVDDataInterface HDF5 FileName: " << file_name << std::endl;
+      std::cout << "PDVDDataInterface Run:Event:Seq: " << runno << ":" << evtno << ":" << seqno << std::endl;
+    }
+
+
+  // Fetches SourceIDs for the set of Fragments that have TriggerPrimitive data in them.
+  art::ServiceHandle<dune::HDF5RawFile3Service> rawFileService;
+  auto rf = rawFileService->GetPtr();
+ 
+  auto tp_sourceids = rf->get_source_ids_for_fragment_type(rid, dunedaq::daqdataformats::FragmentType::kTriggerPrimitive);
+  auto ta_sourceids = rf->get_source_ids_for_fragment_type(rid, dunedaq::daqdataformats::FragmentType::kTriggerActivity);
+  auto tc_sourceids = rf->get_source_ids_for_fragment_type(rid, dunedaq::daqdataformats::FragmentType::kTriggerCandidate);
+
+
+  // Loop over SourceIDs, Calculates the number of TriggerPrimitive objects in the individual Fragment Payload 
+  if (fDebugLevel > 0)
+    {  
+      std::cout << "runno:" << runno << " ; " << rf->get_source_ids(rid).size() << " ;  " << tp_sourceids.size() << " ; " << ta_sourceids.size() << " ; " << tc_sourceids.size() << std::endl;
+    }
+
+ 
+  for (auto const& source_id : tp_sourceids)
+    {
+      // Perform a check to make sure we are only grabbing information from the trigger
+      if (source_id.subsystem != dunedaq::daqdataformats::SourceID::Subsystem::kTrigger) continue;
+      
+      auto frag_ptr = rf->get_frag_ptr(rid, source_id);
+      auto frag_size = frag_ptr->get_size();
+      size_t fhs = sizeof(dunedaq::daqdataformats::FragmentHeader);
+      
+      if (frag_size <= fhs) continue; // Too small to even have a header
+      
+      size_t tps = sizeof(dunedaq::trgdataformats2::TriggerPrimitive);
+      size_t this_sid_no_of_tps = (frag_size - fhs) / tps;
+      size_t current_no_of_tps = tp_col.size();
+      void* frag_payload_ptr = frag_ptr->get_data();
+
+      
+      // Now you can take the block of data where frag_payload_ptr points to and copy this block of data into a vector of TriggerPrimitives,
+      // trig_vector
+      tp_col.resize(current_no_of_tps+this_sid_no_of_tps);
+      memcpy(&(tp_col[current_no_of_tps]), frag_payload_ptr, this_sid_no_of_tps * tps);
+
+      for (size_t i = current_no_of_tps; i < tp_col.size(); ++i)
+      {
+	    if (fDebugLevel > 0)
+	    {
+	      std::cout << source_id << "   ;    " << i << "    ;    "  << tp_col.at(i).channel << "    ;    " << tp_col.at(i).time_start << "  ;  " << tp_col.at(i).version << std::endl;
+	    }
+      }
+      
+    
+    } // for (auto const& source_id : tp_sourceids)
+  
+  
+
+  for (auto const& source_id : ta_sourceids)
+    {
+      if (source_id.subsystem != dunedaq::daqdataformats::SourceID::Subsystem::kTrigger) continue;
+
+      auto frag_ptr = rf->get_frag_ptr(rid, source_id);
+      auto frag_size = frag_ptr->get_size();
+      size_t fhs = sizeof(dunedaq::daqdataformats::FragmentHeader);
+
+      if (frag_size <= fhs) continue;
+
+      //loop over the data, one TA at a time
+      long remaining_data_size = (long)(frag_size-fhs);
+      char* data_ptr = (char*)(frag_ptr->get_data());
+      while(remaining_data_size>0) {
+          //create our overlay object
+          const dunedaq::trgdataformats2::TriggerActivity& overlay =
+                  *reinterpret_cast<const dunedaq::trgdataformats2::TriggerActivity*>(data_ptr);
+
+          //get its size
+          auto this_size = sizeof(dunedaq::trgdataformats2::TriggerActivity::data_t) + //size of TriggerActivityData
+                   sizeof(uint64_t) + //n_inputs is uint64_t
+                   overlay.n_inputs*sizeof(dunedaq::trgdataformats2::TriggerActivity::input_t); //size of TP inputs
+
+          //put our TA data on the output collection
+          ta_col.emplace_back(overlay.data);
+
+          //create an art::Ptr for it
+          auto const taPtr = taPtrMaker(ta_col.size()-1);
+
+          //loop through the TPs in the TA, add them to a new collection and make Assns to the TA
+          for(size_t i_tp=0; i_tp<overlay.n_inputs; ++i_tp) {
+              tps_in_tas_col.emplace_back(overlay.inputs[i_tp]);
+              auto const tpPtr = tpInTAPtrMaker(tps_in_tas_col.size()-1);
+              tp_in_tas_assn.addSingle(taPtr,tpPtr);
+          }
+          //move the read position forward
+          remaining_data_size = remaining_data_size-(long)this_size;
+          data_ptr += this_size;
+
+      } //end while(remaining_data_size>0)
+    }
+
+      
+      
+  for (auto const& source_id : tc_sourceids)
+    {
+      if (source_id.subsystem != dunedaq::daqdataformats::SourceID::Subsystem::kTrigger) continue;
+
+      auto frag_ptr = rf->get_frag_ptr(rid, source_id);
+      auto frag_size = frag_ptr->get_size();
+      size_t fhs = sizeof(dunedaq::daqdataformats::FragmentHeader);
+
+      if (frag_size <= fhs) continue;
+
+      //loop over the data, one TA at a time
+      long remaining_data_size = (long)(frag_size-fhs);
+      char* data_ptr = (char*)(frag_ptr->get_data());
+
+      while(remaining_data_size>0) {
+          //create our overlay object
+          const dunedaq::trgdataformats2::TriggerCandidate& overlay =
+                  *reinterpret_cast<const dunedaq::trgdataformats2::TriggerCandidate*>(data_ptr);
+
+          //get its size
+          auto this_size = sizeof(dunedaq::trgdataformats2::TriggerCandidate::data_t) + //size of TriggerCandidateData
+                  sizeof(uint64_t) + //n_inputs is uint64_t
+                  overlay.n_inputs*sizeof(dunedaq::trgdataformats2::TriggerCandidate::input_t); //size of TA inputs
+
+          //put our TC data on the output collection
+          tc_col.emplace_back(overlay.data);
+
+          //create an art::Ptr for it
+          auto const tcPtr = tcPtrMaker(tc_col.size()-1);
+
+          //loop through the TPs in the TA, add them to a new collection and make Assns to the TA
+          for(size_t i_ta=0; i_ta<overlay.n_inputs; ++i_ta) {
+              tas_in_tcs_col.emplace_back(overlay.inputs[i_ta]);
+              auto const taPtr = taInTCPtrMaker(tas_in_tcs_col.size()-1);
+              ta_in_tcs_assn.addSingle(tcPtr,taPtr);
+          }
+
+          //move the read position forward
+          remaining_data_size = remaining_data_size-(long)this_size;
+          data_ptr += this_size;
+
+      } //end while(remaining_data_size>0)
+    }
+
+
+  //the tps that were pulled in from the readout
+  e.put(std::make_unique<std::vector<dunedaq::trgdataformats2::TriggerPrimitive>>(std::move(tp_col)),fOutputInstance);
+
+  //the tas that were pulled in from the trigger system, the tps inside those tas, and assn of them
+  e.put(std::make_unique<std::vector<dunedaq::trgdataformats2::TriggerActivityData>>(std::move(ta_col)),fOutputInstance);
+  e.put(std::make_unique<std::vector<dunedaq::trgdataformats2::TriggerPrimitive>>(std::move(tps_in_tas_col)),fOutputInstance+"inTAs");
+  e.put(std::make_unique< art::Assns<dunedaq::trgdataformats2::TriggerActivityData,dunedaq::trgdataformats2::TriggerPrimitive>>(std::move(tp_in_tas_assn)),fOutputInstance);
+
+  //the tcs that were pulled in from the trigger system, the tas inside those tcs, and assn of them
+  e.put(std::make_unique<std::vector<dunedaq::trgdataformats2::TriggerCandidateData>>(std::move(tc_col)),fOutputInstance);
+  e.put(std::make_unique<std::vector<dunedaq::trgdataformats2::TriggerActivityData>>(std::move(tas_in_tcs_col)),fOutputInstance+"inTCs");
+  e.put(std::make_unique< art::Assns<dunedaq::trgdataformats2::TriggerCandidateData,dunedaq::trgdataformats2::TriggerActivityData>>(std::move(ta_in_tcs_assn)),fOutputInstance);
+
+}
+
+DEFINE_ART_MODULE(PDVDTriggerReader4)


### PR DESCRIPTION
This is a copy of pdvdtriggerreader3_module.cc with the new TP, TA and TC formats released in April 2025, in dunedetdataformats v4_4_5.  Specifically, the TP format now takes half the size it used to.  The class names of the TP, TA and TC structs are the same, though the namespaces are now dunedaq::trgdataformats2 instead of dunedaq::trgdataformats.