### PR TITLE
Daphne update for PDVD

### DIFF
--- a/duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt
+++ b/duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt
@@ -297,6 +297,28 @@ cet_build_plugin(DAPHNEInterface2   art::tool LIBRARIES
                         HDF5::HDF5
              )
 
+cet_build_plugin(DAPHNEInterface3   art::tool LIBRARIES
+                        canvas::canvas
+                        cetlib::cetlib
+                        cetlib_except::cetlib_except
+                        lardataobj::RawData
+                        dunepdlegacy::Overlays
+                        duneprototypes_Protodune_hd_ChannelMap_DAPHNEChannelMapService_service
+                        DAPHNEUtils
+			art::Framework_Core
+                        art::Framework_Principal
+                        art::Framework_Services_Registry
+                        art_root_io::tfile_support
+                        ROOT::Core
+                        art_root_io::TFileService_service
+                        art::Persistency_Provenance
+                        messagefacility::MF_MessageLogger
+                        ROOT::Core ROOT::Hist ROOT::Tree
+			dunecore::HDF5Utils_HDF5RawFile3Service_service
+			dunecore::dunedaqhdf5utils2
+                        HDF5::HDF5
+             )
+
 #cet_make_library(PDHDReadoutUtils
 #                 SOURCE PDHDReadoutUtils.cxx
 #                 LIBRARIES INTERFACE

--- a/duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterface1_tool.cc
+++ b/duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterface1_tool.cc
@@ -234,6 +234,12 @@ class DAPHNEInterface1 : public DAPHNEInterfaceBase {
       }
     }
   };
+    void Process2(
+      art::Event &evt,
+      std::string inputlabel,
+      std::vector<std::string> subdet_label,
+      std::unordered_map<unsigned int, WaveformVector> & wf_map,
+      utils::DAPHNETree * daphne_tree) override {};
 
 };
 }

--- a/duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterface3_tool.cc
+++ b/duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterface3_tool.cc
@@ -1,3 +1,6 @@
+/* New Daphne Interface, adapted from DAPHNEInterface2 to deal with
+ a vector of subdet_label required for PDVD */
+
 #include "DAPHNEInterfaceBase.h"
 #include "dunecore/DuneObj/DUNEHDF5FileInfo2.h"
 #include "dunecore/HDF5Utils/HDF5RawFile3Service.h"
@@ -17,7 +20,7 @@ using dunedaq::daqdataformats::FragmentHeader;
 using DAPHNEStreamFrame = dunedaq::fddetdataformats::Daphnestreamframe2;
 using DAPHNEFrame = dunedaq::fddetdataformats::Daphneframe2;
 
-class DAPHNEInterface2 : public DAPHNEInterfaceBase {
+class DAPHNEInterface3 : public DAPHNEInterfaceBase {
 
  private:
   static const size_t FragmentHeaderSize = sizeof(FragmentHeader);
@@ -191,12 +194,12 @@ class DAPHNEInterface2 : public DAPHNEInterfaceBase {
 
  public:
 
-  DAPHNEInterface2(fhicl::ParameterSet const& p) {};
+  DAPHNEInterface3(fhicl::ParameterSet const& p) {};
 
-  void Process(
+  void Process2(
       art::Event &evt,
       std::string inputlabel,
-      std::string subdet_label,
+      std::vector<std::string> subdet_label,
       std::unordered_map<unsigned int, WaveformVector> & wf_map,
       utils::DAPHNETree * daphne_tree) override {
 
@@ -234,13 +237,15 @@ class DAPHNEInterface2 : public DAPHNEInterfaceBase {
       }
     }
   };
-    void Process2(
+  
+  void Process(
       art::Event &evt,
       std::string inputlabel,
-      std::vector<std::string> subdet_label,
-      std::unordered_map<unsigned int, WaveformVector> & wf_map,
+      std::string subdet_label,
+      std::unordered_map<unsigned int, std::vector<raw::OpDetWaveform>> & wf_map,
       utils::DAPHNETree * daphne_tree) override {};
+
 };
 }
 
-DEFINE_ART_CLASS_TOOL(daphne::DAPHNEInterface2)
+DEFINE_ART_CLASS_TOOL(daphne::DAPHNEInterface3)

--- a/duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterfaceBase.h
+++ b/duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterfaceBase.h
@@ -24,6 +24,12 @@ class DAPHNEInterfaceBase {
       std::string subdet_label,
       std::unordered_map<unsigned int, std::vector<raw::OpDetWaveform>> & wf_map,
       utils::DAPHNETree * daphne_tree) = 0;
+  virtual void Process2(
+      art::Event &evt,
+      std::string inputlabel,
+      std::vector<std::string> subdet_label,
+      std::unordered_map<unsigned int, std::vector<raw::OpDetWaveform>> & wf_map,
+      utils::DAPHNETree * daphne_tree) = 0;
 
   virtual ~DAPHNEInterfaceBase() = default;
  protected:

--- a/duneprototypes/Protodune/hd/RawDecoding/DAPHNEUtils.cxx
+++ b/duneprototypes/Protodune/hd/RawDecoding/DAPHNEUtils.cxx
@@ -79,4 +79,17 @@ bool CheckSubdet(size_t geo_id, std::string subdet_label) {
 
 }
 
+
+bool CheckSubdet(size_t geo_id, std::vector<std::string> &subdet_label) {
+  dunedaq::detdataformats::DetID::Subdetector det_idenum
+      = static_cast<dunedaq::detdataformats::DetID::Subdetector>(
+          0xffff & geo_id);
+
+  //Check that it's photon detectors
+  auto subdetector_string
+      = dunedaq::detdataformats::DetID::subdetector_to_string(det_idenum);
+  return !(std::find(subdet_label.begin(), subdet_label.end(), subdetector_string) == subdet_label.end());
+
+}
+
 }

--- a/duneprototypes/Protodune/hd/RawDecoding/DAPHNEUtils.h
+++ b/duneprototypes/Protodune/hd/RawDecoding/DAPHNEUtils.h
@@ -40,6 +40,7 @@ namespace utils {
     std::unordered_map<unsigned int, WaveformVector> & wf_map,
     bool is_stream = false);
     bool CheckSubdet(size_t geo_id, std::string subdet_label);
+    bool CheckSubdet(size_t geo_id, std::vector<std::string> &subdet_label);
 }
 }
 

--- a/duneprototypes/Protodune/vd/RawDecoding/CMakeLists.txt
+++ b/duneprototypes/Protodune/vd/RawDecoding/CMakeLists.txt
@@ -23,6 +23,26 @@ cet_build_plugin(PDVDTPCReader art::module LIBRARIES
 )
 
 
+cet_build_plugin(DAPHNEReaderPDVD art::module LIBRARIES
+                 #PDHDReadoutUtils
+                 lardataobj::RawData
+		 dunecore::HDF5Utils_HDF5RawFile2Service_service
+		 dunecore::dunedaqhdf5utils2
+                 duneprototypes_Protodune_hd_ChannelMap_DAPHNEChannelMapService_service
+                 HDF5::HDF5
+                 art::Framework_Core
+                 art::Framework_Principal
+                 art::Framework_Services_Registry
+                 art_root_io::tfile_support
+                 ROOT::Core
+                 art_root_io::TFileService_service
+                 art::Persistency_Provenance
+                 messagefacility::MF_MessageLogger
+                 ROOT::Core ROOT::Hist ROOT::Tree
+                 DAPHNEUtils
+                 BASENAME_ONLY
+)
+
 cet_build_plugin(PDVDDataInterfaceWIBEth   art::tool LIBRARIES
                         canvas::canvas
                         cetlib::cetlib

--- a/duneprototypes/Protodune/vd/RawDecoding/DAPHNEReaderPDVD_module.cc
+++ b/duneprototypes/Protodune/vd/RawDecoding/DAPHNEReaderPDVD_module.cc
@@ -1,0 +1,141 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       DAPHNEReaderPDVD
+// Plugin Type: producer (Unknown Unknown)
+// File:        DAPHNEReaderPDVD_module.cc
+// Adapted to use DaphneInterface3 (deal with several fSubDetString)
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "duneprototypes/Protodune/hd/ChannelMap/DAPHNEChannelMapService.h"
+#include "art/Utilities/make_tool.h" 
+
+#include "duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterfaceBase.h"
+#include "duneprototypes/Protodune/hd/RawDecoding/DAPHNEUtils.h"
+
+#include "lardataobj/RawData/OpDetWaveform.h"
+#include "TTree.h"
+#include "art_root_io/TFileService.h"
+
+#include <memory>
+namespace pdhd {
+
+//For brevity 
+using WaveformVector = std::vector<raw::OpDetWaveform>;
+
+class DAPHNEReaderPDVD;
+
+  // clang complained -- commenting out
+  //const Int_t kMaxFrames = 50;
+
+class DAPHNEReaderPDVD : public art::EDProducer {
+public:
+  explicit DAPHNEReaderPDVD(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  DAPHNEReaderPDVD(DAPHNEReaderPDVD const&) = delete;
+  DAPHNEReaderPDVD(DAPHNEReaderPDVD&&) = delete;
+  DAPHNEReaderPDVD& operator=(DAPHNEReaderPDVD const&) = delete;
+  DAPHNEReaderPDVD& operator=(DAPHNEReaderPDVD&&) = delete;
+
+  // Required functions.
+  void produce(art::Event& e) override;
+  void beginJob() override;
+  void endJob() override;
+
+private:
+
+  std::unique_ptr<daphne::DAPHNEInterfaceBase> fDAPHNETool;
+  daphne::utils::DAPHNETree * fDAPHNETree = nullptr;
+  std::string fInputLabel, fOutputLabel, fFileInfoLabel ;
+  std::vector<std::string> fSubDetString;
+  TTree * fWaveformTree;
+
+  bool fExportWaveformTree;
+  //vars per event
+  //int _Run;
+  // clang complained -- commenting out
+  //int _SubRun;
+  //int _Event;
+  //int _TriggerNumber;
+  //long int _TimeStamp;
+  //long int _Window_end;
+  //long int _Window_begin;
+  //int _NFrames;
+  //int _Slot;
+  //int _Crate;
+  //int _DaphneChannel;
+  //int _OfflineChannel;
+  //long int _FrameTimestamp;
+  //short _adc_value[1024];
+  //int _TriggerSampleValue;
+  //int _Threshold;
+  //int _Baseline;
+};
+}
+
+void pdhd::DAPHNEReaderPDVD::beginJob() {
+  art::ServiceHandle<art::TFileService> tfs;
+
+  if (fExportWaveformTree) {
+    fWaveformTree = tfs->make<TTree>("WaveformTree","Waveforms Tree");
+
+    fDAPHNETree = new daphne::utils::DAPHNETree(fWaveformTree);
+  }
+}
+
+pdhd::DAPHNEReaderPDVD::DAPHNEReaderPDVD(fhicl::ParameterSet const& p)
+  : EDProducer{p}, 
+    fDAPHNETool{
+        art::make_tool<daphne::DAPHNEInterfaceBase>(
+            p.get<fhicl::ParameterSet>("DAPHNEInterface"))},
+    fInputLabel(p.get<std::string>("InputLabel", "daq")),
+    fOutputLabel(p.get<std::string>("OutputLabel", "daq")),
+    fFileInfoLabel(p.get<std::string>("FileInfoLabel", "daq")),
+    fSubDetString(p.get<std::vector<std::string>>("SubDetString",{"VD_Membrane_PDS","VD_Cathode_PDS","VD_PMT_PDS"})),
+    fExportWaveformTree(p.get<bool>("ExportWaveformTree",true)) {
+  produces<std::vector<raw::OpDetWaveform>> (fOutputLabel);
+}
+
+void pdhd::DAPHNEReaderPDVD::produce(art::Event& evt) {
+
+//std::cout << "RUNNIN NEW EVENT ==================" << std::endl;
+
+  WaveformVector opdet_waveforms;
+  std::unordered_map<unsigned int, WaveformVector> wf_map;
+
+  //Process the event
+  fDAPHNETool->Process2(evt, fFileInfoLabel, fSubDetString, wf_map, fDAPHNETree);
+
+  //Convert map to vector for output
+  for (auto & chan_wf_vector : wf_map) {//Loop over channels
+    //std::cout << "Inserting " << chan_wf_vector.first << " " << chan_wf_vector.second.size() << std::endl;
+    opdet_waveforms.insert(opdet_waveforms.end(),
+                           chan_wf_vector.second.begin(),
+                           chan_wf_vector.second.end());
+    //Remove elements from wf_map to save memory
+    chan_wf_vector.second.clear();
+  }
+  //std::cout << "EventNumber " << _Event << std::endl;
+
+  evt.put(
+      std::make_unique<decltype(opdet_waveforms)>(std::move(opdet_waveforms)),
+      fOutputLabel
+  );
+
+}
+
+void pdhd::DAPHNEReaderPDVD::endJob() {
+  if (fDAPHNETree != nullptr) delete fDAPHNETree;
+}
+
+DEFINE_ART_MODULE(pdhd::DAPHNEReaderPDVD)


### PR DESCRIPTION
New daphne interface added to deal with several subdet labels, as it is needed for PDVD: There are cathode and membrane arapucas, and PMTs.
