### PR TITLE
Fix PDVD raw::OpDetWaveform timestamp units and precision

### DIFF
--- a/duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt
+++ b/duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt
@@ -159,7 +159,7 @@ cet_build_plugin(PDHDDataInterfaceWIBEth3   art::tool LIBRARIES
 			dunecore::dunedaqhdf5utils3
                         HDF5::HDF5
              )
-	   
+
 
 cet_build_plugin(PDHDTriggerReader art::module LIBRARIES
                         lardataobj::RawData
@@ -317,6 +317,8 @@ cet_build_plugin(DAPHNEInterface3   art::tool LIBRARIES
 			dunecore::HDF5Utils_HDF5RawFile3Service_service
 			dunecore::dunedaqhdf5utils2
                         HDF5::HDF5
+                        lardataalg::DetectorInfo
+                        lardata::DetectorClocksService
              )
 
 #cet_make_library(PDHDReadoutUtils

--- a/duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterface3_tool.cc
+++ b/duneprototypes/Protodune/hd/RawDecoding/DAPHNEInterface3_tool.cc
@@ -126,7 +126,8 @@ class DAPHNEInterface3 : public DAPHNEInterfaceBase {
       auto & waveform = daphne::utils::MakeWaveform(
             offline_channel,
             frame->s_adcs_per_channel,
-            frame->get_timestamp()*fClocksData->OpticalClock().TickPeriod(), // making sure the timestamp is in microseconds; assumed it's in ticks in DAQ
+            (frame->get_timestamp() & 0xffffffffff) // mask out most significant bits. Live with only 40 least significant bits ~ 1,099,511,627,776 ticks = ~4.9 h
+            *fClocksData->OpticalClock().TickPeriod(), // making sure the timestamp is in microseconds; assumed it's in ticks in DAQ
             wf_map,
             true);
 
@@ -181,7 +182,8 @@ class DAPHNEInterface3 : public DAPHNEInterfaceBase {
     auto & waveform = daphne::utils::MakeWaveform(
         offline_channel,
         static_cast<size_t>(frame->s_num_adcs),
-        frame->get_timestamp()*fClocksData->OpticalClock().TickPeriod(), // making sure the timestamp is in microseconds; assumed it's in ticks in DAQ
+        (frame->get_timestamp() & 0xffffffffff) // mask out most significant bits. Live with only 40 least significant bits ~ 1,099,511,627,776 ticks = ~4.9 h
+        *fClocksData->OpticalClock().TickPeriod(), // making sure the timestamp is in microseconds; assumed it's in ticks in DAQ
         wf_map);
     for (size_t j = 0; j < static_cast<size_t>(frame->s_num_adcs); ++j) {
       waveform.push_back(frame->get_adc(j));


### PR DESCRIPTION
These changes solve issues with how  `raw::OpDetWaveform` stores its timestamp in `DAPHNEInterface3_tool`, which is used by the decoder in PDVD:
1. units expected in the upstream workflow - `OpHitFinder` - are microseconds
2. timestamp in ticks (16 ns) since the Epoch need 57-bit precision but `raw::OpDetWaveform` stores it as a double, which has only 53-bit precision and we are currently losing 4 bits = 16 ticks = 256 ns.

Solutions
1. add `DetectorClocksService` and do the conversion to microseconds based on the OpDet clocks
2. Mask out most significant bits of the input wfm timestamp (held as uint64) before its implicit conversion to double - keep only 40 least significant bits of the time stamp. I believe this solution was used for ProtoDUNE SP.

This has been tested on PDVD data and it showed improved time resolution in signal timing.

I don't know if this tool is used for PDHD, I remember version 2 used to be used in the keepup. If PDHD uses a different tool, same fix will be needed there too, in order to get the desired precision and meaningful interpretation at the OpHit level and beyond.